### PR TITLE
fix: add degree/radian conversion in twist

### DIFF
--- a/oxts_ins/src/conversions/wrapper.cpp
+++ b/oxts_ins/src/conversions/wrapper.cpp
@@ -287,9 +287,9 @@ geometry_msgs::msg::TwistStamped velocity(const NComRxC *nrx,
   msg.twist.linear.x = imu_v.getX();
   msg.twist.linear.y = imu_v.getY();
   msg.twist.linear.z = imu_v.getZ();
-  msg.twist.angular.x = imu_w.getX();
-  msg.twist.angular.y = imu_w.getY();
-  msg.twist.angular.z = imu_w.getZ();
+  msg.twist.angular.x = imu_w.getX() * NAV_CONST::DEG2RADS;
+  msg.twist.angular.y = imu_w.getY() * NAV_CONST::DEG2RADS;
+  msg.twist.angular.z = imu_w.getZ() * NAV_CONST::DEG2RADS;
 
   return msg;
 }


### PR DESCRIPTION
This pull request includes a change to the `oxts_ins/src/conversions/wrapper.cpp` file to ensure the correct conversion of angular velocity from degrees to radians. 

* `geometry_msgs::msg::TwistStamped velocity(const NComRxC *nrx,` in `oxts_ins/src/conversions/wrapper.cpp`: Modified the assignment of `msg.twist.angular` components to multiply by `NAV_CONST::DEG2RADS` for converting angular velocity from degrees to radians.